### PR TITLE
use rebar to fetch webmachine instead of git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "lib/popup-el"]
 	path = lib/popup-el
 	url = https://github.com/tjarvstrand/popup-el.git
-[submodule "lib/webmachine"]
-	path = lib/webmachine
-	url = https://github.com/basho/webmachine.git

--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,4 @@ MAKEFLAGS=-s
 all:
 	@-if [ -z "${EDTS_SKIP_SUBMODULE_UPDATE}" ]; \
 	  then git submodule update --init; fi
-	@cd lib/webmachine && $(MAKE) MAKEFLAGS="$(MAKEFLAGS)"
 	@cd lib/edts && $(MAKE) MAKEFLAGS="$(MAKEFLAGS)"

--- a/lib/edts/Makefile
+++ b/lib/edts/Makefile
@@ -2,7 +2,7 @@ suite=$(if $(SUITE), suite=$(SUITE), )
 
 .PHONY:	all deps check test clean
 
-all:
+all: deps
 	./rebar compile
 
 deps:

--- a/lib/edts/rebar.config
+++ b/lib/edts/rebar.config
@@ -1,3 +1,13 @@
-{lib_dirs,            [".."]}.
-{erl_opts,            [debug_info]}.
-{deps,                [ ]}.
+%% -*- mode: erlang; erlang-indent-level: 2; indent-tabs-mode: nil -*-
+
+{lib_dirs, [".."]}.
+{deps_dir, [".."]}.
+{erl_opts, [debug_info]}.
+{deps,     [ {webmachine, "1.8.1",
+              {git, "git://github.com/basho/webmachine",
+               {tag, "webmachine-1.8.1"}}}
+           ]}.
+
+{cover_enabled,       true}.
+{cover_print_enabled, true}.
+{xref_checks,         [undefined_function_calls]}.


### PR DESCRIPTION
webmachine no longer a submodule; but fetched as a rebar dependency

Points I wasn't sure about
-- should the elisp and erlang stuff go into the same lib/ directory
-- how do I actually regression test this?

Other
-- no eunit or ct tests ;) for shame!
