### PR TITLE
run start.sh from any directory

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -21,6 +21,8 @@
 ###############################################################################
 
 ERL=${1:-$(which erl)}
-PWD=$(pwd)
+EDTS_HOME="$( cd "$( dirname "$0" )" && pwd )"
 
-exec $ERL -sname edts -pa $PWD/lib/*/ebin $PWD/lib/*/deps/*/ebin -s edts_app
+cd $EDTS_HOME
+
+exec $ERL -sname edts -pa $EDTS_HOME/lib/*/ebin $EDTS_HOME/lib/*/deps/*/ebin -s edts_app


### PR DESCRIPTION
Now you can run start.sh from any directory and the erlang vm will stil run within
edts path
