### PR TITLE
Makes unspecified include paths relative to project root

### DIFF
--- a/lib/edts/src/edts_code.erl
+++ b/lib/edts/src/edts_code.erl
@@ -263,7 +263,11 @@ get_compile_cwd(M, [{attribute,1,file,{RelPath,1}}|_]) ->
   CompileInfo = M:module_info(compile),
   CompileOpts = proplists:get_value(options, CompileInfo),
   case proplists:get_value(cwd, CompileOpts, undefined) of
-    undefined -> pop_dirs(proplists:get_value(source, CompileInfo), RelPath);
+    undefined ->
+        case pop_dirs(proplists:get_value(source, CompileInfo), RelPath) of
+            [] -> {ok, Cwd} = file:get_cwd(), Cwd;
+            Cwd -> Cwd
+        end;
     Cwd       -> Cwd
   end.
 


### PR DESCRIPTION
-include_lib("proper/include/proper.hrl"). gives me following error:
"edts-search-includes: Opening input file: no such file or directory, /deps/proper/include/proper.hrl" error.

As I've investigated, Erlang's filename:join("", "test/path") returns absolute path "/test/path", so after pop_dirs in edts_code:get_compile_cwd/2 we got probably incorrect absolute path.

This patch can fix this.
