### PR TITLE
Encode eunit description to utf-8 binary

### DIFF
--- a/lib/edts/src/edts_resource_eunit.erl
+++ b/lib/edts/src/edts_resource_eunit.erl
@@ -83,7 +83,7 @@ format_test({Type, File, Line, Desc}) ->
   {struct, [ {type, Type}
            , {file, list_to_binary(File)}
            , {line, Line}
-           , {description, list_to_binary(Desc)}]}.
+           , {description, unicode:characters_to_binary(Desc)}]}.
 
 %%%_* Internal functions =======================================================
 


### PR DESCRIPTION
This should fix the crash reported by Samuel
