### PR TITLE
Better function finding regexp

### DIFF
--- a/elisp/edts/edts-man.el
+++ b/elisp/edts/edts-man.el
@@ -184,7 +184,11 @@ interactively to set up your man-pages instead")
 `edts-man-root'."
   (edts-man-find-module module)
   (let (foundp
-        (re (format "^[[:space:]]*\\(%s\\)" function)))
+        (re (format 
+             (cond
+              ((zerop arity) "^[[:blank:]]*\\(%s\\)() ->")
+              (t "^[[:blank:]]*\\(%s\\)(\\(?:\\w+,[[:blank:]]\\)\\{%s\\}\\w+) ->"))
+             function (1- arity))))
     (while (and (not foundp) (re-search-forward re))
       (save-excursion
         (goto-char (match-beginning 1))

--- a/elisp/edts/edts.el
+++ b/elisp/edts/edts.el
@@ -625,7 +625,10 @@ non-nil, don't report an error if the request fails."
 (defun edts-node-name ()
   "Return the sname of current buffer's project node."
   (condition-case ex
-      (eproject-attribute :node-sname)
+      (let ((name 
+             (eproject-attribute :node-sname)))
+        (or name
+            (edts-shell-node-name (get-buffer "*edts*"))))
     ('error (edts-shell-node-name))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Current regexp finds first function name entrance, this improvement matches brackets and '->' sign to find exactly function section in man, and also respects arity to check number of words (probably with commas) inside brackets.
