### PR TITLE
Added a function clause to edts_eunit:format_error to handle exits in a ...

### DIFF
--- a/lib/edts/src/edts_eunit.erl
+++ b/lib/edts/src/edts_eunit.erl
@@ -153,8 +153,8 @@ format_error({error, {Reason, Info} = Err, _Stack}) ->
     {error, not_found} ->
       io_lib:format("~p", [Err])
   end;
-format_error({exit,Err,_Stack}) ->
-  io_lib:format("~p", [Err]);
+format_error({Err,Reason,_Stack}) ->
+  io_lib:format("~p", [{Err,Reason}]);
 format_error(Err) ->
   io_lib:format("~p", [Err]).
 

--- a/lib/edts/src/edts_eunit.erl
+++ b/lib/edts/src/edts_eunit.erl
@@ -152,7 +152,10 @@ format_error({error, {Reason, Info} = Err, _Stack}) ->
                     [Reason, to_str(Expected), to_str(Value)]);
     {error, not_found} ->
       io_lib:format("~p", [Err])
-  end.
+  end;
+format_error({exit,Err,Stack}) ->
+  io_lib:format("~p", [Err]).
+
 
 get_line(Result) ->
   case proplists:get_value(line, Result) of

--- a/lib/edts/src/edts_eunit.erl
+++ b/lib/edts/src/edts_eunit.erl
@@ -153,7 +153,9 @@ format_error({error, {Reason, Info} = Err, _Stack}) ->
     {error, not_found} ->
       io_lib:format("~p", [Err])
   end;
-format_error({exit,Err,Stack}) ->
+format_error({exit,Err,_Stack}) ->
+  io_lib:format("~p", [Err]);
+format_error(Err) ->
   io_lib:format("~p", [Err]).
 
 


### PR DESCRIPTION
I got the following error in edts_resource_eunit:resource_exists/2 attempting to run a test suite:

```
{badmatch,{error,not_found}}
```

The cause was a function-clause in edits_eunit:format_error/1 which prevented edts_resource_eunit form obtaining the eunit test results. The reason for the function-clause was because my test suite failed with:

```
{'EXIT',{aborted,{no_exists, some_mnesia_table}}}
```

which didnt match the expected {error, Reason}. The fix could be to add a catch all clause to format_error. My pull request just adds code for the exit case.
