### PR TITLE
Autocomplete function name with arity inside an export statement

### DIFF
--- a/elisp/edts/edts-complete.el
+++ b/elisp/edts/edts-complete.el
@@ -96,8 +96,9 @@ character before that."
         char)))
 
 (defadvice ac-expand-string (before edts-complete-trim-arity)
-  "Removes any /x at the end of completion string"
-  (ad-set-arg 0 (replace-regexp-in-string "/[0-9]+$" "" (ad-get-arg 0))))
+  "Removes any /x at the end of completion string unless point is in an export list"
+  (when      (ferl-is-point-in-export-list)  ())
+  (when (not (ferl-is-point-in-export-list)) (ad-set-arg 0 (replace-regexp-in-string "/[0-9]+$" "" (ad-get-arg 0)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Setup

--- a/elisp/edts/ferl.el
+++ b/elisp/edts/ferl.el
@@ -153,4 +153,17 @@ of (function-name . starting-point)."
   (when (eq (char-after) ?:)
     (forward-sexp)))
 
+(defun ferl-is-point-in-export-list ()
+  "Return t if point is inside an export definition list else nil"
+  (save-excursion
+    (let ((res nil) (oldpoint (point)))
+    (goto-char (point-min))
+      (unwind-protect
+	  (progn
+	    (while (re-search-forward "^-export\\s *(\\s *\\[" oldpoint t)
+	      (setq res t)
+	      (while (and (re-search-forward "\\]" oldpoint t) (not (erlang-in-literal))) 
+	        (setq res nil)))
+	    res)))))
+
 (provide 'ferl)


### PR DESCRIPTION
Added code for this. It first checks if point is with an export list before removing the /x in the function auto complete.

I have tested manually in emacs but when I tried to run the integration tests I get:

```
`flet' is an obsolete macro (as of 24.3); use either `cl-flet' or `cl-letf'.
`labels' is an obsolete macro (as of 24.3); use `cl-labels' instead.
`flet' is an obsolete macro (as of 24.3); use either `cl-flet' or `cl-letf'.
`flet' is an obsolete macro (as of 24.3); use either `cl-flet' or `cl-letf'.
`flet' is an obsolete macro (as of 24.3); use either `cl-flet' or `cl-letf'.
`flet' is an obsolete macro (as of 24.3); use either `cl-flet' or `cl-letf'.
`flet' is an obsolete macro (as of 24.3); use either `cl-flet' or `cl-letf'.
Symbol's value as variable is void: erlang-operators-regexp
make: *** [ert] Error 255
```
