### PR TITLE
Autocomplete function name with arity inside an export statement

### DIFF
--- a/elisp/edts/edts-complete.el
+++ b/elisp/edts/edts-complete.el
@@ -97,8 +97,7 @@ character before that."
 
 (defadvice ac-expand-string (before edts-complete-trim-arity)
   "Removes any /x at the end of completion string unless point is in an export list"
-  (when      (ferl-is-point-in-export-list-p)  ())
-  (when (not (ferl-is-point-in-export-list-p)) (ad-set-arg 0 (replace-regexp-in-string "/[0-9]+$" "" (ad-get-arg 0)))))
+  (unless (ferl-is-point-in-export-list-p) (ad-set-arg 0 (replace-regexp-in-string "/[0-9]+$" "" (ad-get-arg 0)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Setup

--- a/elisp/edts/edts-complete.el
+++ b/elisp/edts/edts-complete.el
@@ -97,8 +97,8 @@ character before that."
 
 (defadvice ac-expand-string (before edts-complete-trim-arity)
   "Removes any /x at the end of completion string unless point is in an export list"
-  (when      (ferl-is-point-in-export-list)  ())
-  (when (not (ferl-is-point-in-export-list)) (ad-set-arg 0 (replace-regexp-in-string "/[0-9]+$" "" (ad-get-arg 0)))))
+  (when      (ferl-is-point-in-export-list-p)  ())
+  (when (not (ferl-is-point-in-export-list-p)) (ad-set-arg 0 (replace-regexp-in-string "/[0-9]+$" "" (ad-get-arg 0)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Setup

--- a/elisp/edts/edts-complete.el
+++ b/elisp/edts/edts-complete.el
@@ -96,8 +96,9 @@ character before that."
         char)))
 
 (defadvice ac-expand-string (before edts-complete-trim-arity)
-  "Removes any /x at the end of completion string"
-  (ad-set-arg 0 (replace-regexp-in-string "/[0-9]+$" "" (ad-get-arg 0))))
+  "Removes any /x at the end of completion string unless point is in an export list"
+  (when      (ferl-is-point-in-export-list)  ())
+  (when (not (ferl-is-point-in-export-list)) (ad-set-arg 0 (replace-regexp-in-string "/[0-9]+$" "" (ad-get-arg 0)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Setup

--- a/elisp/edts/ferl.el
+++ b/elisp/edts/ferl.el
@@ -158,9 +158,10 @@ of (function-name . starting-point)."
   (save-excursion
     (let ((oldpoint (point)))
       (if (re-search-backward "^-export\\s-*(\\s-*\\[" nil t)
-          (progn 
-            (goto-char (1- (match-end 0)))
-            (forward-sexp)
-            (> (point) oldpoint))))))
+          (condition-case ex
+              (progn
+                (forward-sexp)
+                (> (point) oldpoint))
+            (error t))))))
 
 (provide 'ferl)

--- a/elisp/edts/ferl.el
+++ b/elisp/edts/ferl.el
@@ -153,17 +153,19 @@ of (function-name . starting-point)."
   (when (eq (char-after) ?:)
     (forward-sexp)))
 
-(defun ferl-is-point-in-export-list ()
+(defun ferl-is-point-in-export-list-p ()
   "Return t if point is inside an export definition list else nil"
   (save-excursion
     (let ((res nil) (oldpoint (point)))
     (goto-char (point-min))
       (unwind-protect
 	  (progn
-	    (while (re-search-forward "^-export\\s *(\\s *\\[" oldpoint t)
-	      (setq res t)
-	      (while (and (re-search-forward "\\]" oldpoint t) (not (erlang-in-literal))) 
-	        (setq res nil)))
-	    res)))))
+	    (while (and (not res) (re-search-forward "^-export\\s-*(" oldpoint t) )
+	      (erlang-skip-blank)
+              (if (eq (following-char) ?\[)
+                (progn
+                  (forward-sexp)
+                  (setq res (> (point) oldpoint))) ))
+            res)))))
 
 (provide 'ferl)

--- a/elisp/edts/ferl.el
+++ b/elisp/edts/ferl.el
@@ -158,13 +158,12 @@ of (function-name . starting-point)."
   (save-excursion
     (let ((res nil) (oldpoint (point)))
     (goto-char (point-min))
-    (progn
-      (while (and (not res) (re-search-forward "^-export\\s-*(" oldpoint t) )
-        (erlang-skip-blank)
-        (if (eq (following-char) ?\[)
-            (progn
-              (forward-sexp)
-              (setq res (> (point) oldpoint))) ))
-      res))))
+    (while (and (not res) (re-search-forward "^-export\\s-*(" oldpoint t) )
+      (erlang-skip-blank)
+      (if (eq (following-char) ?\[)
+          (progn
+            (forward-sexp)
+            (setq res (> (point) oldpoint))) ))
+    res)))
 
 (provide 'ferl)

--- a/elisp/edts/ferl.el
+++ b/elisp/edts/ferl.el
@@ -153,4 +153,17 @@ of (function-name . starting-point)."
   (when (eq (char-after) ?:)
     (forward-sexp)))
 
+(defun ferl-is-point-in-export-list ()
+  "Return t if point is inside an export definition list else nil"
+  (save-excursion
+    (let ((res nil) (oldpoint (point)))
+    (goto-char (point-min))
+      (unwind-protect
+	  (progn
+	    (while (re-search-forward "^-export\\s *(\\s *\\[" oldpoint t)
+	      (setq res t)
+	      (while (and (re-search-forward "\\]" oldpoint t) (not (erlang-in-literal))) 
+	        (setq res nil)))
+	    res)))))
+
 (provide 'ferl)

--- a/elisp/edts/ferl.el
+++ b/elisp/edts/ferl.el
@@ -156,14 +156,11 @@ of (function-name . starting-point)."
 (defun ferl-is-point-in-export-list-p ()
   "Return t if point is inside an export definition list else nil"
   (save-excursion
-    (let ((res nil) (oldpoint (point)))
-    (goto-char (point-min))
-    (while (and (not res) (re-search-forward "^-export\\s-*(" oldpoint t) )
-      (erlang-skip-blank)
-      (if (eq (following-char) ?\[)
-          (progn
+    (let ((oldpoint (point)))
+      (if (re-search-backward "^-export\\s-*(\\s-*\\[" nil t)
+          (progn 
+            (goto-char (1- (match-end 0)))
             (forward-sexp)
-            (setq res (> (point) oldpoint))) ))
-    res)))
+            (> (point) oldpoint))))))
 
 (provide 'ferl)

--- a/elisp/edts/ferl.el
+++ b/elisp/edts/ferl.el
@@ -158,14 +158,13 @@ of (function-name . starting-point)."
   (save-excursion
     (let ((res nil) (oldpoint (point)))
     (goto-char (point-min))
-      (unwind-protect
-	  (progn
-	    (while (and (not res) (re-search-forward "^-export\\s-*(" oldpoint t) )
-	      (erlang-skip-blank)
-              (if (eq (following-char) ?\[)
-                (progn
-                  (forward-sexp)
-                  (setq res (> (point) oldpoint))) ))
-            res)))))
+    (progn
+      (while (and (not res) (re-search-forward "^-export\\s-*(" oldpoint t) )
+        (erlang-skip-blank)
+        (if (eq (following-char) ?\[)
+            (progn
+              (forward-sexp)
+              (setq res (> (point) oldpoint))) ))
+      res))))
 
 (provide 'ferl)


### PR DESCRIPTION
A fix for Issue #12. Sorry tried to link but dont have permission.
The enhancement checks if point is inside a -export list and if so it does not drop the arity string /x from the completed function name
