### PR TITLE
initialization crashed with error:undef

### DIFF
--- a/lib/edts/src/edts_server.erl
+++ b/lib/edts/src/edts_server.erl
@@ -336,7 +336,7 @@ plugins() ->
     undefined -> [];
     {ok, Dir} ->
       {ok, PluginDirs} = file:list_dir(Dir),
-      [list_to_atom(PluginDir) || PluginDir <- PluginDirs]
+      [list_to_atom(PluginDir) || PluginDir <- PluginDirs, PluginDir =/= ".gitignore"]
   end.
 
 init_node_env(Node, AppEnv) ->


### PR DESCRIPTION
A .gitignore file in the plugins/ directory caused a undef error in edts_server:do_init_node (line 306)
