### PR TITLE
added missing goto-char from ferl-is-point-in-export-list-p.

### DIFF
--- a/elisp/edts/ferl.el
+++ b/elisp/edts/ferl.el
@@ -160,6 +160,7 @@ of (function-name . starting-point)."
       (if (re-search-backward "^-export\\s-*(\\s-*\\[" nil t)
           (condition-case ex
               (progn
+                (goto-char (1- (match-end 0)))
                 (forward-sexp)
                 (> (point) oldpoint))
             (error t))))))


### PR DESCRIPTION
Hey, sorry in my last refactor for issue #12 I left out the  (goto-char (1- (match-end 0))) to move the cursor to the beginning of the export list. Please will you merge this in as well. Thank you.
