### PR TITLE
add string param type so that the string format of the paramter can be p...

### DIFF
--- a/lib/edts/src/edts_resource_plugin_call.erl
+++ b/lib/edts/src/edts_resource_plugin_call.erl
@@ -117,9 +117,11 @@ convert_params(Params, Specs) ->
             end,
             Specs).
 
-convert_param(Vs, [T]) -> [convert_param(V, T) || V <- string:tokens(Vs, ",")];
-convert_param(V,  pid) -> erlang:list_to_pid("<" ++ V ++ ">");
-convert_param(V,  T)   -> apply(erlang, ?l2a("list_to_" ++ ?a2l(T)), [V]).
+convert_param(Vs, [T])    -> [ convert_param(V, T) ||
+                               V <- string:tokens(Vs, ",")];
+convert_param(V,  pid)    -> erlang:list_to_pid("<" ++ V ++ ">");
+convert_param(V,  string) -> V;
+convert_param(V,  T)      -> apply(erlang, ?l2a("list_to_" ++ ?a2l(T)), [V]).
 
 convert_return(Ret) when is_list(Ret) ->
   IsProp = fun({K, _V}) when is_atom(K) -> true;


### PR DESCRIPTION
...assed to the plugin for further processing.

one of the parameters of a plugin call that i implement is not of trivial data types like integer or atom. it is a list of arbitrary erlang terms. i thought perhaps edts should allow plugin to receive the parameter in its raw string format and deal with it by itself. what do you think?
