### PR TITLE
fixed after save error

### DIFF
--- a/plugins/edts_xref/edts-xref.el
+++ b/plugins/edts_xref/edts-xref.el
@@ -126,7 +126,8 @@ parsed response as the single argument"
   (let* ((err-alist  (edts-code--issue-to-file-map analysis-res)))
     ;; Set the error list in each project-buffer
     (with-each-buffer-in-project (gen-sym) (eproject-root)
-      (let ((errors (cdr (assoc (file-truename (buffer-file-name)) err-alist))))
+      (let* ((file-name (or (buffer-file-name) default-directory))
+             (errors (cdr (assoc (file-truename file-name) err-alist))))
         (edts-code--set-issues 'edts-xref (list 'error errors))
         (edts-face-update-buffer-mode-line (edts-code-buffer-status))
         (when errors

--- a/plugins/edts_xref/edts-xref.el
+++ b/plugins/edts_xref/edts-xref.el
@@ -126,12 +126,12 @@ parsed response as the single argument"
   (let* ((err-alist  (edts-code--issue-to-file-map analysis-res)))
     ;; Set the error list in each project-buffer
     (with-each-buffer-in-project (gen-sym) (eproject-root)
-      (let* ((file-name (or (buffer-file-name) default-directory))
-             (errors (cdr (assoc (file-truename file-name) err-alist))))
-        (edts-code--set-issues 'edts-xref (list 'error errors))
-        (edts-face-update-buffer-mode-line (edts-code-buffer-status))
-        (when errors
-          (edts-code-display-error-overlays 'edts-xref errors))))))
+      (when (buffer-file-name)
+        (let ((errors (cdr (assoc (file-truename (buffer-file-name)) err-alist))))
+          (edts-code--set-issues 'edts-xref (list 'error errors))
+          (edts-face-update-buffer-mode-line (edts-code-buffer-status))
+          (when errors
+            (edts-code-display-error-overlays 'edts-xref errors)))))))
 
 
 (defun edts-xref-get-who-calls (module function arity)


### PR DESCRIPTION
Here's fix for issue https://github.com/tjarvstrand/edts/issues/108
It happens since dired buffers belong to edts-project. Dired's buffer `(buffer-file-name)` always return nil.

That might be not pretty correct "fix". We can consider exclude dired buffers from edts-project.
