### PR TITLE
Correctly set default node-sname derived from name

### DIFF
--- a/elisp/edts/edts-project.el
+++ b/elisp/edts/edts-project.el
@@ -240,7 +240,7 @@ Example:
       (unless (eproject-attribute :node-sname)
         (edts-project-set-attribute
          root
-         :node-sname (eproject-name)))
+         :node-sname (edts-project--make-node-name (eproject-attribute :name))))
       (unless (eproject-attribute :start-command)
         (edts-project-set-attribute
          root
@@ -334,7 +334,7 @@ FILE."
   (let ((node-name (or node-name
 		       (eproject-attribute :node-sname)
 		       (eproject-name))))
-    (format "erl -sname %s" (edts-project--make-node-name node-name))))
+    (format "erl -sname %s" node-name)))
 
 (defun edts-project--make-node-name (src)
   "Construct a default node-sname for current buffer's project node."


### PR DESCRIPTION
wasn't working for cases when the folder name actually contained invalid chars (as per `edts-project--make-node-name`)
