### PR TITLE
add 'deps' to default :lib-dirs

### DIFF
--- a/elisp/edts/edts-project.el
+++ b/elisp/edts/edts-project.el
@@ -129,7 +129,7 @@ Example:
                    "\\.yaws$")
   :irrelevant-files ("^\\.gitignore$"
                      "^\\.gitmodules$")
-  :lib-dirs ("lib"))
+  :lib-dirs ("lib" "deps"))
 
 (defun edts-project-selector (file-name)
   "Try to figure out if FILE should be part of an edts-project."


### PR DESCRIPTION
Every rebar based project's `.edts` file needs `:lib-dirs "deps"` in order for auto completion to work on those deps.

We could get the desired effect by also creating some kind of function like `edts-project-override` except that it could be like a global append. This doesn't do that, and was much easier to implement :D
