### PR TITLE
fixed complete-macro undefined function call

### DIFF
--- a/elisp/edts/edts-complete-macro-source.el
+++ b/elisp/edts/edts-complete-macro-source.el
@@ -78,7 +78,7 @@ candidates, except we single-quote-terminate candidates."
 (defun edts-complete-find-module-macros ()
   (let* ((files  (cons (buffer-file-name) (edts-api-get-includes)))
          (macros   (apply #'append
-                          (mapcar #'edts-complete-get-file-macros files)))
+                          (mapcar #'edts-complete-parse-get-file-macros files)))
          (parsed  (edts-complete-parse-macros macros)))
     parsed))
 


### PR DESCRIPTION
Fixes macro completion.
Fixes errors in `*Messages*`:

```
Error running timer `ac-show-menu': (void-function edts-complete-get-file-macros)
Error running timer `ac-update-greedy': (void-function edts-complete-get-file-macros)
```
