### PR TITLE
#158 use filename:basename instead of lists:suffix to get file source

### DIFF
--- a/lib/edts/src/edts_code.erl
+++ b/lib/edts/src/edts_code.erl
@@ -181,7 +181,9 @@ make_function_info(M, F, A, ExportedP, FunSrc, Line, ModSrc) ->
       absolute -> FunSrc;
       relative ->
         % Deals with File = "./src". Must be a better way to do this.
-        case lists:suffix(FunSrc, ModSrc) of
+        BaseFunSrc = filename:basename(FunSrc),
+        BaseModSrc = filename:basename(ModSrc),
+        case BaseFunSrc =:= BaseModSrc of
           true  -> ModSrc;
           false -> filename:join(filename:dirname(ModSrc), FunSrc)
         end


### PR DESCRIPTION
Use filename:basename instead of lists:suffix to get file source to resolve #158 
