### PR TITLE
Slow project node start fixes

### DIFF
--- a/elisp/edts/edts-api.el
+++ b/elisp/edts/edts-api.el
@@ -125,17 +125,40 @@ localhost."
         (if (> retries 0)
             ;; Wait same more
             (if edts-api-async-node-init
-                (run-with-idle-timer 0.5
-                                     nil
-                                     'edts-api-init-node-when-ready
-                                     project-name
-                                     node-name
-                                     root
-                                     libs
-                                     app-include-dirs
-                                     project-include-dirs
-                                     erlang-cookie
-                                     (1- retries))
+                ;; This used to use run-with-idle-timer.  A problem
+                ;; with that is that we risk checking immediately
+                ;; thereby exhausting the retries very quickly which
+                ;; is a problem on slower systems.
+                ;;
+                ;;   * Assume the interval is 0.5 s.
+                ;;   * Assume we leave emacs idle, then the timer
+                ;;     triggers after 0.5 s.
+                ;;   * The function will now add another 0.5 s idle
+                ;;     timer, but the time is counted from when emacs
+                ;;     became idle and the funtion will trigger
+                ;;     immediately.
+                ;;   * We could add the (current-idle-time) to the 0.5
+                ;;     second interval, but then we have a problem if
+                ;;     emacs goes from idle to active and then to idle
+                ;;     a second time.  Now we have an idle timer with
+                ;;     a (let's say) 4.5 second interval. In this case
+                ;;     we would have to reset the timer's interval
+                ;;     when emacs goes from active to idle.
+                ;;
+                ;; We could make it more complex by making this work
+                ;; with idleness, but hopefully using the regular
+                ;; run-with-timer doesn't load emacs too much.
+                (run-with-timer 0.5
+                                nil
+                                'edts-api-init-node-when-ready
+                                project-name
+                                node-name
+                                root
+                                libs
+                                app-include-dirs
+                                project-include-dirs
+                                erlang-cookie
+                                (1- retries))
               ;; Synchronous init
               (sit-for 0.5)
               (edts-api-init-node-when-ready project-name

--- a/elisp/edts/edts-api.el
+++ b/elisp/edts/edts-api.el
@@ -49,6 +49,16 @@ that is not part of a project")
   :type 'number
   :group 'edts)
 
+(defcustom edts-api-num-project-node-start-retries 5
+  "The number of retries to wait for a project node to start before giving up"
+  :type 'integer
+  :group 'edts)
+
+(defcustom edts-api-project-node-start-retry-interval 0.5
+  "Time between each project node availability check at start up"
+  :type 'number
+  :group 'edts)
+
 (defvar edts-api--pending-node-startups nil
   "List of nodes that we are waiting on to get ready for registration.")
 
@@ -117,7 +127,7 @@ localhost."
                                       retries)
   "Once NODE-NAME is registered with epmd, register it with the edts server."
   (add-to-list 'edts-api--pending-node-startups node-name)
-  (let ((retries (or retries 5)))
+  (let ((retries (or retries edts-api-num-project-node-start-retries)))
     (edts-log-debug "Waiting for node %s to start (retries %s)"
                     node-name
                     retries)
@@ -148,7 +158,7 @@ localhost."
                 ;; We could make it more complex by making this work
                 ;; with idleness, but hopefully using the regular
                 ;; run-with-timer doesn't load emacs too much.
-                (run-with-timer 0.5
+                (run-with-timer edts-api-project-node-start-retry-interval
                                 nil
                                 'edts-api-init-node-when-ready
                                 project-name
@@ -160,7 +170,7 @@ localhost."
                                 erlang-cookie
                                 (1- retries))
               ;; Synchronous init
-              (sit-for 0.5)
+              (sit-for edts-api-project-node-start-retry-interval)
               (edts-api-init-node-when-ready project-name
                                              node-name
                                              root


### PR DESCRIPTION
Hi,

I've made to commits related to project node starts in edts-api-init-node-when-ready.  Please let me know what you think.

What can I say, some of our systems are slow... :-)

Cheers,
Klas
