### PR TITLE
Specify types for all defcustoms

### DIFF
--- a/edts-mode.el
+++ b/edts-mode.el
@@ -46,6 +46,7 @@
        (warn
         "No erl on exec-path. Most of EDTS' functionality will be broken.")))
   "Location of the erl-executable to use when launching the main EDTS-node."
+  :type 'file
   :group 'edts)
 
 (eval-and-compile
@@ -66,6 +67,7 @@
       (expand-file-name "edts" user-emacs-directory)
     (expand-file-name "~/.emacs.d"))
   "Where EDTS should save its data."
+  :type 'directory
   :group 'edts)
 
 (defconst edts-lib-directory

--- a/edts-start.el
+++ b/edts-start.el
@@ -8,6 +8,7 @@
 
 (defcustom edts-inhibit-package-check nil
   "If non-nil, don't check whether EDTS was installed as a package."
+  :type 'boolean
   :group 'edts)
 
 (unless (or edts-inhibit-package-check
@@ -49,6 +50,7 @@
     "\\.script$"
     "\\.yaws$")
   "File-name patterns for which to auto-activate edts-mode."
+  :type '(repeat regexp)
   :group 'edts)
 
 (mapc #'(lambda(re) (add-to-list 'auto-mode-alist (cons re 'erlang-mode)))

--- a/elisp/edts/edts-api.el
+++ b/elisp/edts/edts-api.el
@@ -36,14 +36,17 @@ that is not part of a project")
 
 (defcustom edts-api-async-node-init t
   "Whether or not node initialization should be synchronous"
+  :type 'boolean
   :group 'edts)
 
 (defcustom edts-api-num-server-start-retries 20
   "The number of retries to wait for server to start before giving up"
+  :type 'integer
   :group 'edts)
 
 (defcustom edts-api-server-start-retry-interval 0.2
   "Time between each server availability check at start up"
+  :type 'number
   :group 'edts)
 
 (defvar edts-api--pending-node-startups nil

--- a/elisp/edts/edts-complete.el
+++ b/elisp/edts/edts-complete.el
@@ -52,6 +52,7 @@
     edts-complete-macro-source
     edts-complete-record-source)
   "Sources that EDTS uses for auto-completion."
+  :type '(repeat symbol)
   :group 'edts)
 
 (defcustom edts-complete-shell-sources
@@ -61,6 +62,7 @@
     edts-complete-module-source)
   "Sources that EDTS uses for auto-completion in shell (comint)
 buffers."
+  :type '(repeat symbol)
   :group 'edts)
 
 (defun edts-complete-setup (&optional sources)

--- a/elisp/edts/edts-face.el
+++ b/elisp/edts/edts-face.el
@@ -30,11 +30,14 @@
 
 (defcustom edts-face-inhibit-fringe-markers nil
   "If non-nil, do not display markers in the fringe for errors etc."
+  :type 'boolean
   :group 'edts)
 
 (defcustom edts-face-marker-fringe 'left-fringe
   "Which side to display fringe-markers on. The value must be either
 left-fringe or right-fringe."
+  :type '(choice (const :tag "Left fringe" left-fringe)
+		 (const :tag "Right fringe" right-fringe))
   :group 'edts)
 
 (defcustom edts-face-inhibit-mode-line-updates nil

--- a/elisp/edts/edts-log.el
+++ b/elisp/edts/edts-log.el
@@ -28,6 +28,11 @@
 
 (defcustom edts-log-level 'info
   "The current EDTS log-level."
+  :type '(choice
+	  (const error)
+	  (const warning)
+	  (const info)
+	  (const debug))
   :group 'edts)
 
 (defconst edts-log-default-level 'error

--- a/elisp/edts/edts-shell.el
+++ b/elisp/edts/edts-shell.el
@@ -48,6 +48,7 @@ list is itself an alist of the shell's properties.")
     edts-complete-module-source)
   "Sources that EDTS uses for auto-completion in shell (comint)
 buffers."
+  :type '(repeat symbol)
   :group 'edts)
 
 (defcustom edts-shell-inhibit-comint-input-highlight t

--- a/plugins/edts_debug/edts-debug.el
+++ b/plugins/edts_debug/edts-debug.el
@@ -64,6 +64,7 @@ request should always be outstanding if we are not already attached.")
 
 (defcustom edts-debug-auto-attach t
   "If non-nil, automatically enter debug-mode when a breakpoint is hit."
+  :type 'boolean
   :group 'edts)
 
 (defvar edts-debug-node nil

--- a/plugins/edts_xref/edts-xref.el
+++ b/plugins/edts_xref/edts-xref.el
@@ -29,6 +29,9 @@
 (defcustom edts-xref-checks '(undefined_function_calls)
   "What xref checks EDTS should perform. A list of 0 or more of
 undefined_function_calls, unexported_functions"
+  :type '(set
+	  (const undefined_function_calls)
+	  (const unexported_functions))
   :group 'edts)
 
 (defvar edts-xref-initialized-nodes nil


### PR DESCRIPTION
This makes the customize interface more convenient to use, as you don't
have to enter "raw" Lisp expressions.
