### PR TITLE
Reduce CPU usage after wake up from suspend

### DIFF
--- a/lib/edts/src/edts_module_server.erl
+++ b/lib/edts/src/edts_module_server.erl
@@ -102,7 +102,7 @@ start() ->
                       {stop, term()}.
 %%------------------------------------------------------------------------------
 init(_Args) ->
-  {ok, TRef} = timer:send_interval(3000, update),
+  {ok, TRef} = timer:send_after(3000, update),
   {ok, #state{modules = fetch_modules(),
               timerref = TRef}}.
 
@@ -140,7 +140,9 @@ handle_cast(_Message, State) -> {noreply, State}.
                                             {stop, Reason::term(), state()}.
 %%------------------------------------------------------------------------------
 handle_info(update, State) ->
-  {noreply, State#state{modules = fetch_modules()}};
+  Modules = fetch_modules(),
+  {ok, TRef} = timer:send_after(3000, update),
+  {noreply, State#state{modules = Modules, timerref = TRef}};
 handle_info(_Info, State) ->
   {noreply, State}.
 


### PR DESCRIPTION
Assume edts has started a project node and that the computer is then
suspended.  After waking up hours later, "ps" revealed that the beam
process for a project node used close to 100% CPU.  Running the observer
app inside that node revealed that the edts_module_server had a very
long (thousands) message queue consisting of `update' messages.  The
edts_module_server was catching up on all those messages it missed while
asleep.

This commit replaces the timer:send_interval by timer:send_after.  A new
timer is started once the previous update message has been processed,
making sure that no avalanche of update messages is set off after waking
up.
