### PR TITLE
Add missing require 'edts-navigate

### DIFF
--- a/elisp/edts/edts.el
+++ b/elisp/edts/edts.el
@@ -29,6 +29,7 @@
 (require 'edts-doc)
 (require 'edts-event)
 (require 'edts-api)
+(require 'edts-navigate)
 
 (eval-and-compile
   (defvar edts-built-in-functions


### PR DESCRIPTION
If you disabled the xref plugin edts navigate functionality would break
since it wasn't required by edts, but by only by the xref plugin.
