### PR TITLE
Protecting shell variables so that paths containing whitespace work.

### DIFF
--- a/start
+++ b/start
@@ -25,11 +25,11 @@ ERL=${2:-$(which erl)}
 EDTS_HOME="$( cd "$( dirname "$0" )" && pwd )"
 PLUGIN_DIR=$EDTS_HOME/plugins
 
-cd $EDTS_HOME
-exec $ERL \
+cd "$EDTS_HOME"
+exec "$ERL" \
     -sname edts \
     -config "$EDTS_HOME/lib/edts/priv/app" \
     -edts project_data_dir "\"$PROJDIR\"" \
     -edts plugin_dir "\"$PLUGIN_DIR\"" \
-    -pa $EDTS_HOME/{lib,plugins}/*/ebin \
+    -pa "$EDTS_HOME"/{lib,plugins}/*/ebin \
     -s edts_app


### PR DESCRIPTION
This patch adds double quotes in `cd "$EDTS_HOME"`. This is necessary when this path contains whitespace, which is the case by default on some systems (using Aquamacs, the path contains a directory named `Aquamacs Emacs`).
