### PR TITLE
Unique node name per user

### DIFF
--- a/edts-mode.el
+++ b/edts-mode.el
@@ -55,6 +55,12 @@
   :type 'string
   :group 'edts)
 
+(defcustom edts-erl-sname
+  "edts"
+  "Specify an short-name for the EDTS-node. This will help in multiuser-systems."
+  :type 'string
+  :group 'edts)
+
 (eval-and-compile
   (defconst edts-root-directory
     (file-name-directory (or (locate-library "edts-autoloads")

--- a/elisp/edts/edts-api.el
+++ b/elisp/edts/edts-api.el
@@ -78,11 +78,10 @@ requests.")
 the node-name of the node that has gone down as the argument.")
 
 (defvar edts-node-sname
-  (concat "edts_"
-          (let ((s (shell-command-to-string "whoami")))
-            (if (string-match "[ \t\r\n]+" s) (replace-match "" t t s) s)))
-  "Sets the edts node sname to `edts_<username>'. This makes it
-possible to have several edts nodes on the same host.")
+  (if (string= "" edts-erl-sname) "edts" edts-erl-sname)
+  "Use `edts-erl-sname' if available. If not the sname will be
+set to \"edts\". This makes it possible to have several edts
+nodes on the same host.")
 (make-variable-buffer-local 'edts-node-sname)
 
 (defun edts-api-ensure-server-started ()
@@ -97,7 +96,7 @@ possible to have several edts nodes on the same host.")
     (error "EDTS: Server already running"))
   (let* ((pwd (f-join (directory-file-name edts-lib-directory) ".."))
          (command (list "./start" edts-data-directory
-                        edts-erl-command edts-node-sname))
+                        edts-erl-command edts-node-sname edts-erl-flags))
          (retries edts-api-num-server-start-retries)
          available)
     (edts-shell-make-comint-buffer "*edts*" edts-node-sname pwd command)

--- a/elisp/edts/edts-api.el
+++ b/elisp/edts/edts-api.el
@@ -77,21 +77,30 @@ requests.")
   "Hooks to run after a node has gone down. These hooks are called with
 the node-name of the node that has gone down as the argument.")
 
+(defvar edts-node-sname
+  (concat "edts_"
+          (let ((s (shell-command-to-string "whoami")))
+            (if (string-match "[ \t\r\n]+" s) (replace-match "" t t s) s)))
+  "Sets the edts node sname to `edts_<username>'. This makes it
+possible to have several edts nodes on the same host.")
+(make-variable-buffer-local 'edts-node-sname)
+
 (defun edts-api-ensure-server-started ()
   "Starts an edts server-node in a comint-buffer unless it is already running."
-  (unless (or (edts-api-node-started-p "edts") (edts-api-start-server))
+  (unless (or (edts-api-node-started-p edts-node-sname) (edts-api-start-server))
     (error "EDTS: Could not start main server")))
 
 (defun edts-api-start-server ()
   "Starts an edts server-node in a comint-buffer"
   (interactive)
-  (when (edts-api-node-started-p "edts")
+  (when (edts-api-node-started-p edts-node-sname)
     (error "EDTS: Server already running"))
   (let* ((pwd (f-join (directory-file-name edts-lib-directory) ".."))
-         (command (list "./start" edts-data-directory edts-erl-command edts-erl-flags))
+         (command (list "./start" edts-data-directory
+                        edts-erl-command edts-node-sname))
          (retries edts-api-num-server-start-retries)
          available)
-    (edts-shell-make-comint-buffer "*edts*" "edts" pwd command)
+    (edts-shell-make-comint-buffer "*edts*" edts-node-sname pwd command)
     (setq available (edts-api-get-nodes t))
     (while (and (> retries 0) (not available))
       (setq available (edts-api-get-nodes t))

--- a/start
+++ b/start
@@ -24,11 +24,13 @@ PROJDIR=${1:-"$HOME"}
 ERL=${2:-$(which erl)}
 EDTS_HOME="$(cd "$(dirname "$0")" >/dev/null && pwd -P)"
 PLUGIN_DIR=$EDTS_HOME/plugins
-EDTS_SNAME=${3:-"edts_$(whoami)"}
+ERL_SNAME=${3:-"edts"}
+ERL_FLAGS=$4
 
 cd "$EDTS_HOME"
 exec "$ERL" \
-    -sname $EDTS_SNAME \
+     $ERL_FLAGS \
+    -sname $ERL_SNAME \
     -config "$EDTS_HOME/lib/edts/priv/app" \
     -edts project_data_dir "\"$PROJDIR\"" \
     -edts plugin_dir "\"$PLUGIN_DIR\"" \

--- a/start
+++ b/start
@@ -24,11 +24,11 @@ PROJDIR=${1:-"$HOME"}
 ERL=${2:-$(which erl)}
 EDTS_HOME="$(cd "$(dirname "$0")" >/dev/null && pwd -P)"
 PLUGIN_DIR=$EDTS_HOME/plugins
+EDTS_SNAME=${3:-"edts_$(whoami)"}
 
 cd "$EDTS_HOME"
 exec "$ERL" \
-    $3 \
-    -sname edts \
+    -sname $EDTS_SNAME \
     -config "$EDTS_HOME/lib/edts/priv/app" \
     -edts project_data_dir "\"$PROJDIR\"" \
     -edts plugin_dir "\"$PLUGIN_DIR\"" \


### PR DESCRIPTION
In order to have multiple edts nodes in the same system (for multiple users), one could set the ERL_EPMD_PORT to a unique port number. This patch instead renames the edts node name to something unique (`edts_<username>').
