### PR TITLE
Workaround for sit-for bug during edts-api-start-server

### DIFF
--- a/elisp/edts/edts-api.el
+++ b/elisp/edts/edts-api.el
@@ -95,7 +95,7 @@ the node-name of the node that has gone down as the argument.")
     (setq available (edts-api-get-nodes t))
     (while (and (> retries 0) (not available))
       (setq available (edts-api-get-nodes t))
-      (sit-for edts-api-server-start-retry-interval)
+      (sleep-for edts-api-server-start-retry-interval)
       (decf retries))
     (when available
       (edts-log-info "Started EDTS server")
@@ -171,7 +171,7 @@ localhost."
                                 erlang-cookie
                                 (1- retries))
               ;; Synchronous init
-              (sit-for edts-api-project-node-start-retry-interval)
+              (sleep-for edts-api-project-node-start-retry-interval)
               (edts-api-init-node-when-ready project-name
                                              node-name
                                              root


### PR DESCRIPTION
There is a bug in sit-for that make the call return immediately
instead of waiting the wanted numer of seconds. This bug has been
around since emacs-23.2 and was fixed Wed, 29 Jul 2015, see:

  https://debbugs.gnu.org/cgi/bugreport.cgi?bug=15990
  https://debbugs.gnu.org/cgi/bugreport.cgi?bug=20935

This bug make EDTS fail to start with the message:

  EDTS: Could not start main server

since the retry loop in edts-api-start-server is executed too fast,
before the web server component has started.

Since a many emacs version are affected many users might get into
trouble for a long period of time. The fix not even been included in a
official emacs release yet. To work around the problem instead of
relying on sit-for also check how long time have passed in the while
loop condition.
