### PR TITLE
change beam's modification time to source's -1 second

### DIFF
--- a/lib/edts/src/edts_code.erl
+++ b/lib/edts/src/edts_code.erl
@@ -119,6 +119,10 @@ compile_and_load(File0, Opts) ->
            true  -> lists:nthtail(length(Cwd) + 1, File0);
            false -> File0
          end,
+  FileLastModified =
+    calendar:datetime_to_gregorian_seconds(filelib:last_modified(File)),
+  BeamLastModified =
+    calendar:gregorian_seconds_to_datetime(FileLastModified - 1),
   OutDir  = get_compile_outdir(File0),
   OldOpts = extract_compile_opts(File),
 
@@ -137,6 +141,7 @@ compile_and_load(File0, Opts) ->
       OutFile = filename:join(OutDir, atom_to_list(Mod)),
       case file:write_file(OutFile ++ ".beam", Bin) of
         ok ->
+          file:change_time(OutFile ++ ".beam", BeamLastModified),
           code:purge(Mod),
           {module, Mod} = code:load_abs(OutFile),
           add_path(OutDir),


### PR DESCRIPTION
fixes #202

This allows the project's main build system to rebuild the BEAM per
the project's settings. Otherwise, since the BEAM's modification
time is newer than the source's, the main build system will think
it has already built it and will skip, possibly hiding warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tjarvstrand/edts/211)
<!-- Reviewable:end -->
