### PR TITLE
fixed regexp for otp man pages

### DIFF
--- a/elisp/edts/edts-man.el
+++ b/elisp/edts/edts-man.el
@@ -100,7 +100,7 @@ Location of the OTP documentation man-pages."
   (with-current-buffer (url-retrieve-synchronously edts-man-download-url)
     (goto-char (point-min))
     (let ((case-fold-search t)
-          (re "<a href=\".*/\\(otp_doc_man_\\(.*?\\)\\.tar\\.gz\\)\">")
+          (re "<a href=\"\\(?:.*/\\)?\\(otp_doc_man_\\(.*?\\)\\.tar\\.gz\\)\">")
           vsn-urls)
       (while (< (point) (point-max))
         (re-search-forward re nil 'move-point)


### PR DESCRIPTION
Should fix #212 

The problem: otp man page links don't have a single slash in URLs, so regular expression failed.

Solution: made slash optional.
