### PR TITLE
Make edts refactor easier to use

### DIFF
--- a/edts-mode.el
+++ b/edts-mode.el
@@ -35,6 +35,7 @@
     (define-key map "\C-c\C-de"    'edts-ahs-edit-current-function)
     (define-key map "\C-c\C-dE"    'edts-ahs-edit-buffer)
     (define-key map "\C-c\C-dt"    'edts-code-eunit)
+    (define-key map "\C-c\C-dr"    'edts-refactor-extract-function)
     (define-key map "\M-."         'edts-find-source-under-point)
     (define-key map "\M-,"         'edts-find-source-unwind)
     map)
@@ -108,6 +109,7 @@
 (require 'edts-face)
 (require 'edts-log)
 (require 'edts-project)
+(require 'edts-refactor)
 (require 'edts-plugin)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -209,8 +211,6 @@ further.
 \\[edts-byte-compile]               - Byte compile all EDTS elisp files.
 \\[edts-project-start-node]         - Start current buffers project-node
                                       if not already running.
-\\[edts-refactor-extract-function]  - Extract code in current region
-                                      into a separate function.
 \\[edts-init-node]                  - Register the project-node of
                                       current buffer with the central
                                       EDTS server.


### PR DESCRIPTION
Require edts refactor file when starting the edts mode.
Bind edts refactor to "\C-c\C-dr" (r as in refactor).
Remove documentation on how to invoke the refactor code without the short command.
