### PR TITLE
Bump mochiweb version to tag v2.18.0

### DIFF
--- a/elisp/edts/edts-api.el
+++ b/elisp/edts/edts-api.el
@@ -1,4 +1,4 @@
-;;; edts.el --- Functions thot do Rest API calls.
+;;; edts.el --- Functions that do Rest API calls.
 
 ;; Copyright 2012-2013 Thomas Järvstrand <tjarvstrand@gmail.com>
 

--- a/lib/edts/rebar.config
+++ b/lib/edts/rebar.config
@@ -6,7 +6,7 @@
             {platform_define, "^[0-9]+", namespaced_types}
            ]}.
 
-{deps,     [{mochiweb,   ".*", {git, "git://github.com/mochi/mochiweb.git",     {tag, "v2.12.2"}}},
+{deps,     [{mochiweb,   ".*", {git, "git://github.com/mochi/mochiweb.git",     {tag, "v2.18.0"}}},
             {meck,       ".*", {git, "git://github.com/eproxus/meck",         {tag,    "0.8.4"}}}
            ]}.
 


### PR DESCRIPTION
Opening erlang files made Emacs freeze when communicating with the EDTS node. C-g worked fine and the file was actually opened. But navigating was really awkward. Updating to a newer mochiweb seems to solve it. Not sure if this is related to OTP versions, I've tried a few versions of 18, and also 19 and 20.
Tested on emacs 24.5.1, 25.2.2, 26.1 and OTP 19.3.6.9, 20.3.6.
