### PR TITLE
try to use erlang-find-tag as fallback

### DIFF
--- a/elisp/edts/edts-navigate.el
+++ b/elisp/edts/edts-navigate.el
@@ -262,8 +262,7 @@ When FUNCTION is specified, the point is moved to its start."
                  (t
                   (edts-log-error ;; Some unknown error
                    "Function %s:%s/%s not found" module function arity))))
-            (edts-log-error
-              "Function %s:%s/%s not found" module function arity))))))
+            (erlang-find-tag (concat module ":" function)))))))
 
 (defun edts-navigate-to-module (module &optional line)
   "Find the source code for MODULE in a buffer, loading it if necessary.


### PR DESCRIPTION
Sometimes edts gets into a weird place where the edts Erlang VM can't find the M:F/A information via `edts_code:get_function_info/3` and just outputs an error. Since I have a TAGS file in the project root, `M-.` can still jump to the first definition of the function (since I don't think `erlang-find-tag` accounts for arity). 