### PR TITLE
Catch error and allow retries

### DIFF
--- a/elisp/edts/edts-rpc.el
+++ b/elisp/edts/edts-rpc.el
@@ -53,7 +53,9 @@
     (setq url-show-status nil)
     (edts-log-debug "Sending call to %s" url)
     (edts-log-debug-2 "Call args: %s" url-request-data)
-    (-when-let (buffer (url-retrieve-synchronously url))
+    (-when-let (buffer (condition-case nil
+                           (url-retrieve-synchronously url)
+                         (error nil)))
       (with-current-buffer buffer
         (let* ((proc (get-buffer-process (current-buffer)))
                (reply  (edts-rpc-parse-http-response))


### PR DESCRIPTION
After updating to OTP 20 the edts node becomes available in epmd but it is still not listening on port 4587. As a result the url-retrieve-synchronously returns an error and that invalidates the retries mechanism of the edts-api-start-server function.

With this patch the retry mechanism will do it's job and the edts node is started.

Tested with OTP 20 and emacs 26.1.