### PR TITLE
Use environment variable EDTS_PORT in edts-rpc.el

### DIFF
--- a/config/vm.args
+++ b/config/vm.args
@@ -1,1 +1,1 @@
--sname edts-server
+-name edts-server@127.0.0.1

--- a/elisp/edts/edts-rpc.el
+++ b/elisp/edts/edts-rpc.el
@@ -35,10 +35,12 @@
 (defvar edts-rpc-suppress-error-codes nil
   "Do not log http errors of requests with these return codes")
 
-(defconst edts-rpc-host "0"
+(defconst edts-rpc-host "localhost"
   "The host where the edts erlang node is running.")
 
-(defconst edts-rpc-port 4587
+(defconst edts-rpc-port (if (getenv "EDTS_PORT")
+  (getenv "EDTS_PORT") 
+  4587)
   "The port on which the edts erlang node's rpc-api is available.")
 
 (defconst edts-rpc-content-type-hdr '("Content-Type" . "application/json"))

--- a/elisp/edts/edts-rpc.el
+++ b/elisp/edts/edts-rpc.el
@@ -35,7 +35,7 @@
 (defvar edts-rpc-suppress-error-codes nil
   "Do not log http errors of requests with these return codes")
 
-(defconst edts-rpc-host "localhost"
+(defconst edts-rpc-host "127.0.0.1"
   "The host where the edts erlang node is running.")
 
 (defconst edts-rpc-port (if (getenv "EDTS_PORT")


### PR DESCRIPTION
Erlang code picks up EDTS_PORT if it exists for the mochiweb server.
Make sure that elisp client also uses the same.
Also the -sname option in config/vm.args creates "nohost" name.
Using -name edts-server@127.0.0.1 seems to pick up the host name instead.