### PR TITLE
Fix issues on edts startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,3 +261,24 @@ of EDTS' `after-save-hook`. The issue does not exist in Emacs 24.
 If you're using proxy server, you have to make sure that the proxy is not used
 for communicating with EDTS:
 ```(add-to-list 'url-proxy-services '("no_proxy" . "0:4587"))```
+
+## Setup edts from source instructions ##
+To setup from source (assuming that you have rebar3 installed and added to your PATH), you first need to clone and compile edts:
+
+```bash
+$ git clone https://github.com/sebastiw/edts
+$ cd edts
+$ make
+```
+
+Next you need to ensure the edts directory is added to the emacs load-path. Add to your `.emacs.d` or `init.el` file:
+
+```
+(add-to-list 'load-path "<path to the cloned edts repo>")
+
+(add-hook 'after-init-hook 'my-after-init-hook)
+(defun my-after-init-hook ()
+  (require 'edts-start))
+```
+
+With this edts fork the .edts file shouldn't be need. Just ensure that you have compiled first your rebar3 project and start emacs.

--- a/elisp/edts/edts-rpc.el
+++ b/elisp/edts/edts-rpc.el
@@ -53,7 +53,9 @@
     (setq url-show-status nil)
     (edts-log-debug "Sending call to %s" url)
     (edts-log-debug-2 "Call args: %s" url-request-data)
-    (-when-let (buffer (url-retrieve-synchronously url))
+    (-when-let (buffer (condition-case nil
+                           (url-retrieve-synchronously url)
+                         (error nil)))
       (with-current-buffer buffer
         (let* ((proc (get-buffer-process (current-buffer)))
                (reply  (edts-rpc-parse-http-response))

--- a/start
+++ b/start
@@ -27,7 +27,5 @@ APP_DIR=$EDTS_HOME/apps
 cd "$EDTS_HOME"
 
 exec $EDTS \
-    -sname $3 \
     -edts project_data_dir "\"$PROJ_DIR\"" \
     -edts plugin_dir "\"$APP_DIR\""
-


### PR DESCRIPTION
This fixes 2 issues:

- Some emacs specific change that stops edts emacs code to retry an HTTP request needed for starting/connecting to an existing node;
- A bug that was preventing the edts server node to start correctly