### PR TITLE
Fix ci issues by setting dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: required
 language: erlang
 otp_release:


### PR DESCRIPTION
Setting the dist to trusty seems to fix travis ci failures. For me, [on master, build failed](https://travis-ci.org/tomas-abrahamsson/edts/builds/630705337), but with this change they seem to succeed. I think travis changed default distribution from trusty to xenial in June this year, and probably not all package versions are cached for all dists. 