### PR TITLE
update mochiweb

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,10 +4,7 @@
             {platform_define, "^[0-9]+", namespaced_types}
            ]}.
 
-{deps, [{mochiweb,
-         {git, "http://github.com/mochi/mochiweb",
-          {tag, "v2.20.0"}}}
-       ]}.
+{deps, [{mochiweb, "2.20.0"}]}.
 
 {cover_enabled, true}.
 {cover_print_enabled, true}.


### PR DESCRIPTION
Using hex.pm package would be faster, with the cache file.
Besides, the github url is https prefix, not http. The url is wrong.