### PR TITLE
Fix start script for Erlang/OTP 27

### DIFF
--- a/start
+++ b/start
@@ -29,6 +29,7 @@ cd "$EDTS_HOME"
 test -f $EDTS || ./edts-escript release edts-release.config
 
 exec $EDTS \
+    -code_path_choice relaxed \
     -edts project_data_dir "\"$PROJ_DIR\"" \
     -edts plugin_dir "\"$APP_DIR\"" \
     -sname edts-server


### PR DESCRIPTION
In Erlang/OTP 27, it is required to set the flag -code_path_choice to relaxed in order to load code from archive files.