### PR TITLE
Fix crash in edts_code:get_compile_cwd/2

### DIFF
--- a/lib/edts/src/edts_code.erl
+++ b/lib/edts/src/edts_code.erl
@@ -356,7 +356,9 @@ get_compile_cwd(M, [{attribute,_,file,{RelPath,1}}|_]) ->
   case proplists:get_value(cwd, CompileOpts, undefined) of
     undefined -> pop_dirs(proplists:get_value(source, CompileInfo), RelPath);
     Cwd       -> Cwd
-  end.
+  end;
+get_compile_cwd(M, [{attribute,0,compile,_}|Rest]) ->
+  get_compile_cwd(M, Rest).
 
 pop_dirs(Source0, Rel) ->
   L = length(filename:split(Rel)),

--- a/test_data/edts-test-project-project-1/Makefile
+++ b/test_data/edts-test-project-project-1/Makefile
@@ -3,6 +3,7 @@ ERL_LIBS = $(shell pwd)/lib
 all:
 	@cd lib/one; erlc -o ebin +debug_info src/*.erl
 	@cd lib/two; erlc -o ebin +debug_info src/*.erl
+	@cd lib/three; erlc -o ebin +debug_info src/*.erl
 
 clean:
 	@rm -f lib/*/ebin/*.beam

--- a/test_data/edts-test-project-project-1/lib/three/include/three.hrl
+++ b/test_data/edts-test-project-project-1/lib/three/include/three.hrl
@@ -1,0 +1,1 @@
+-record(three, {type :: atom()}).

--- a/test_data/edts-test-project-project-1/lib/three/src/three.erl
+++ b/test_data/edts-test-project-project-1/lib/three/src/three.erl
@@ -1,0 +1,15 @@
+-module(three).
+
+-include("../include/three.hrl").
+-include_lib("stdlib/include/ms_transform.hrl").
+
+-export([three_fun/1]).
+
+three_fun(Expected) ->
+  MS = ets:fun2ms(fun(#three{type = Type}) when Type == Expected -> true end),
+  ets:select(?MODULE, MS).
+
+%%%_* Emacs ====================================================================
+%%% Local Variables:
+%%% erlang-indent-level: 2
+%%% End:


### PR DESCRIPTION
If a module has expanded records, the first attribute in the abstract code is not about the module itself but rather a compiler option that has been implicitly added by the Erlang compiler. For example:

```
[{abstract_code,
     {raw_abstract_v1,
         [{attribute,0,compile,{nowarn_unused_record,[[three]]}},
          {attribute,{1,1},file,{"src/three.erl",1}},
```